### PR TITLE
fixed bug where category was not updating correctly

### DIFF
--- a/CampusCoin/MauiProgram.cs
+++ b/CampusCoin/MauiProgram.cs
@@ -61,7 +61,7 @@ public static class MauiProgram
         mauiAppBuilder.Services.AddSingleton<LoginPage>();
         mauiAppBuilder.Services.AddSingleton<RegistrationPage>();
         mauiAppBuilder.Services.AddSingleton<ExpensesTestPage>();
-        mauiAppBuilder.Services.AddSingleton<ExpensesPage>();
+        mauiAppBuilder.Services.AddTransient<ExpensesPage>();
         mauiAppBuilder.Services.AddSingleton<GraphTestPage>();
         mauiAppBuilder.Services.AddSingleton<EditUserAccountInfoPage>();
         mauiAppBuilder.Services.AddSingleton<ResetPasswordPage>();

--- a/CampusCoin/ViewModels/ExpensesPageViewModel.cs
+++ b/CampusCoin/ViewModels/ExpensesPageViewModel.cs
@@ -76,7 +76,7 @@ public partial class ExpensesPageViewModel : ObservableValidator
     public string IsFoodCategory
     {
         get { return "food"; }
-        set { SelectedCategory = "Food"; }
+        set => SelectedCategory = "Food";
     }
 
     public string IsAutoCategory


### PR DESCRIPTION
reloaded expense page after each data submission as a workaround for an issue where the "selectedCategory" property was not updating properly